### PR TITLE
商品情報削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,6 +25,15 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    if user_signed_in? && current_user.id == @items.user_id
+    @items.destroy
+    redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
+
   def new
     @items = Item.new
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,7 +34,7 @@
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
 
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@items.id), data: {turbo_method: :delete}, class:"item-destroy" %>
 
      <% else %>
     


### PR DESCRIPTION
# what
商品情報削除機能の実装
# why
ユーザー自身で出品した商品を削除できるようにするため

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
ouhigyazo.com/bde5a1aa3e36216f41b5a0f575e1bf6f?token=96767b8222f892015228d500eeec5d60